### PR TITLE
On demand injection of Tracer Header

### DIFF
--- a/aem-panel/assets/javascripts/requests.js
+++ b/aem-panel/assets/javascripts/requests.js
@@ -1,4 +1,10 @@
 /**
+ * Port used to communicate with background logic in background.js
+ */
+var port = chrome.runtime.connect({name: "aem-panel"});
+
+
+/**
  * Listen for Requests in the current window and process them accordingly.
  **/
 
@@ -24,6 +30,10 @@ var requests = {
         }
       }
     });
+
+    //Send message to enable tracer headers for *this* tab
+    port.postMessage({"action" : "register", "tabId" : chrome.devtools.inspectedWindow.tabId});
+
   }
 };
 


### PR DESCRIPTION
Currently the Sling Tracer headers are being sent for all active tabs as the listener is global. Changing that to now only do that for requests originating from those tabs where the AEM Panel is active in DevTools.

Upon AEM Panel activation the tab would be registered for header injection. This would ensure that plugin does not interfere with global request processing and headers only get injected for those pages which the developer wants to debug.

Later we can make it more precise if AEM Panel support option of explicit activation of tracing. It makes use of [Chrome Message Passing][1] support to enable interaction between DevTool panel and background js logic

[1]: https://developer.chrome.com/extensions/messaging